### PR TITLE
pycrdt-websocket 0.16.0 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "pycrdt-websocket" %}
-{% set version = "0.15.4" %}
+{% set version = "0.16.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 46612b3580aa70b70fbf20b0adc0b4afec6d95d3bde142739ef26e74dacf4c9e
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
+  sha256: 89d4d830f41028c55cc9877635f73f94f49131ca73ffac7353d0be421150d0fd
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -23,16 +23,18 @@ requirements:
     - python
     - anyio >=3.6.2,<5
     - sqlite-anyio >=0.2.3,<0.3.0
-    - pycrdt >=0.10.3,<0.13.0
+    - pycrdt >=0.12.16,<0.13.0
+    - pycrdt-store >=0.1.0,<0.2.0
 
-# pytest needs hypercorn in conftest.py, which is not available.
+# pytest needs httpx_ws in conftest.py, which is not available.
 test:
   imports:
-    - pycrdt_websocket
-  commands:
-    - pip check
+    - pycrdt.websocket
   requires:
     - pip
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
 
 about:
   home: https://github.com/jupyter-server/pycrdt-websocket


### PR DESCRIPTION
pycrdt-websocket 0.16.0 

**Destination channel:** Defaults

### Links

- [PKG-11770]
- dev_url:        https://github.com/jupyter-server/pycrdt-websocket/tree/0.16.0
- conda_forge:    https://github.com/conda-forge/pycrdt-websocket-feedstock
- pypi:           https://pypi.org/project/pycrdt-websocket/0.16.0
- pypi inspector: https://inspector.pypi.io/project/pycrdt-websocket/0.16.0

### Explanation of changes:

- new version number


[PKG-11770]: https://anaconda.atlassian.net/browse/PKG-11770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ